### PR TITLE
Removed VS Code config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 jest-coverage
 .nyc_output
+.vscode
 coverage
 cypress-coverage/
 cypress/videos

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "workbench.colorTheme": "Aurelia Solarized (dark)"
-}


### PR DESCRIPTION
.vscode removed and added to .gitignore because it contained only workbench colortheme that are not needed for the endusers